### PR TITLE
Symlink clang to clang-3.9 to via update-alternatives

### DIFF
--- a/docker-templates/base/cpp/ubuntu-cmake-clang.dockerfile
+++ b/docker-templates/base/cpp/ubuntu-cmake-clang.dockerfile
@@ -9,6 +9,13 @@ RUN apt-get update && \
     apt-get install cmake clang-3.9 -y  && \
     apt-get clean autoclean && \
     apt-get autoremove -y
+    
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.9 100 \
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.9 \
+    --slave /usr/bin/clang-check clang-check /usr/bin/clang-check-3.9 \
+    --slave /usr/bin/clang-query clang-query /usr/bin/clang-query-3.9 \
+    --slave /usr/bin/clang-rename clang-rename /usr/bin/clang-rename-3.9 \
+    --slave /usr/bin/clang-tblgen clang-tblgen /usr/bin/clang-tblgen-3.9
 
 ADD ./scripts/cmake-build.sh /build.sh
 ADD ./cmake_toolchains/clang.cmake /clang.cmake


### PR DESCRIPTION
On the madduci/docker-ubuntu-cpp:clang-3.9 image, CMake was unable to use clang since it doesn't point to anything. 

There would be a variety of ways to fix this, from editing clang.cmake to use clang-3.9 / clang++-3.9, to adding symlinks directly via
```
$ ln -s /usr/bin/clang-3.9 /usr/bin/clang
$ ln -s /usr/bin/clang++-3.9 /usr/bin/clang++
```
My proposal is just one alternative.

